### PR TITLE
Implement first 80% of travis replacement CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,33 @@
+
+name: Continuous Deployment
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    deploy:
+        name: Run all checks and builds then deploy to github pages
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install Dependencies
+              run: |
+                  sudo apt-get update
+                  sudo make build-dep
+                  sudo apt-get install -y gnuplot
+            - name: Run CI tests
+              run: make test
+
+            - name: Create report pages
+              run: |
+                  make pages
+                  make pages/stats.pdf
+
+            - name: Deploy
+              uses: JamesIves/github-pages-deploy-action@4.1.4
+              with:
+                  branch: gh-pages
+                  folder: pages

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ name: Continuous Deployment
 on:
     push:
         branches:
-            - main
+            - master
 
 jobs:
     deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 
 name: Continuous integration
 
-on: [push]
+on:
+    push:
+    pull_request:
 
 jobs:
     check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 
-name: CI
+name: Continuous integration
 
 on: [push]
 
 jobs:
     check:
-        name: Run all tests and builds
+        name: Run all checks
         runs-on: ubuntu-latest
 
         steps:
@@ -14,10 +14,5 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo make build-dep
-                  sudo apt-get install -y gnuplot
             - name: Run CI tests
               run: make test
-            - name: Create report pages
-              run: |
-                  make pages
-                  make pages/stats.pdf

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,12 +11,13 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Install Dependencies
-              run: sudo make build-dep
-            - name: Install graphing tools
-              run: sudo apt-get install -y gnuplot
+              run: |
+                  sudo apt-get update
+                  sudo make build-dep
+                  sudo apt-get install -y gnuplot
             - name: Run CI tests
               run: make test
             - name: Create report pages
-              run: make pages
-            - name: Create report graphs
-              run: make pages/stats.pdf
+              run: |
+                  make pages
+                  make pages/stats.pdf

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,22 @@
+
+name: CI
+
+on: [push]
+
+jobs:
+    check:
+        name: Run all tests and builds
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Install Dependencies
+              run: sudo make build-dep
+            - name: Install graphing tools
+              run: sudo apt-get install -y gnuplot
+            - name: Run CI tests
+              run: make test
+            - name: Create report pages
+              run: make pages
+            - name: Create report graphs
+              run: make pages/stats.pdf

--- a/templates/make_balance.html.j2
+++ b/templates/make_balance.html.j2
@@ -143,8 +143,8 @@ body {
 
 <div class="lastupdate">
   Data last updated {{ _hack_timenow }}
-  <a href="https://travis-ci.org/dimsumlabs/dsl-accounts/builds">
-    <img src="https://travis-ci.org/dimsumlabs/dsl-accounts.svg?branch=master">
+  <a href="https://github.com/dimsumlabs/dsl-accounts/actions">
+    <img src="https://github.com/dimsumlabs/dsl-accounts/actions/workflows/cd.yml/badge.svg">
   </a>
 </div>
 </body>


### PR DESCRIPTION
After merging this, the tests will be running again.  Also, any commits to master will be built and published to the gh-pages branch of this repo.

The second 80% of the work involves changes not in this version control:
- Configure github to publish the gh-pages branch to https://dimsumlabs.github.io/dsl-accounts
- Change the screen in the space to use the new url
- Change the door to download its dataset from the new url (see repo dimsumlabs/hackman hackman_payments/management/commands/import_payments.py)

Once all this is done and known working, it is probably worth removing the old .travis.yml and deleting the old dsl-accounts-pages repo