### PR TITLE
Add a simple overlay message example

### DIFF
--- a/templates/make_balance.html.j2
+++ b/templates/make_balance.html.j2
@@ -91,6 +91,28 @@ body {
     border-style: none none none dotted;
 }
 
+#overlay_dim {
+  position: fixed; /* Sit on top of the page content */
+  width: 100%; /* Full width (cover the whole page) */
+  height: 100%; /* Full height (cover the whole page) */
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5); /* Black background with opacity */
+  z-index: 2; /* Specify a stack order in case you're using a different order for other elements */
+}
+
+#overlay_text{
+  position: absolute;
+  top: 25%;
+  left: 50%;
+  font-size: 50px;
+  color: red;
+  transform: rotate(-45deg) translate(-50%,-50%);
+}
+
+
 </style>
 </head>
 <body>
@@ -147,5 +169,8 @@ body {
     <img src="https://github.com/dimsumlabs/dsl-accounts/actions/workflows/cd.yml/badge.svg">
   </a>
 </div>
+<!-- If needed, this can be uncommented
+<div id="overlay_dim"><div id="overlay_text">BROKEN!</div></div>
+-->
 </body>
 </html>


### PR DESCRIPTION
If the repository is broken, the comment at the end of the template or
matching generated index.html can be uncommented to quickly show on any
screens that the data is out of date or otherwise wrong.

TODO:
- perhaps add some javascript to compare the timestamp last updated with
  the timestamp now and automatically show an overlay if it is unexpectedly
  old.